### PR TITLE
Added sanity checks

### DIFF
--- a/main.c
+++ b/main.c
@@ -534,16 +534,21 @@ static MappedFile *sort_mapped_files(MappedFile *mapped_files)
 static char *pid_to_name(pid_t pid)
 {
     char *filename;
-    asprintf(&filename, "/proc/%d/cmdline", pid);
+    char *f;
+    if (asprintf(&filename, "/proc/%d/cmdline", pid) == -1)
+    	return strdup("");
     FILE *fp = fopen(filename, "r");
     free(filename);
 
     if (fp) {
         char line[256];
-        fgets(line, sizeof(line), fp);
+        f = fgets(line, sizeof(line), fp);
         fclose(fp);
 
-        return strdup(line);
+        if (f == NULL)
+        	return strdup("");
+        else
+            return strdup(line);
     } else
         return strdup("");
 }


### PR DESCRIPTION
Check return values of 'asprintf' and 'fgets', which could indicate read/allocation errors.
This also fixes compilation warnings about ignoring return value of these functions (-Wunused-result)
